### PR TITLE
Workaround ProjectItem.HasMetadata

### DIFF
--- a/IceBuilder.Next/source.extension.vsixmanifest
+++ b/IceBuilder.Next/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="0CEF9F9D-FA1F-45D0-9D1E-BBD2A86D5F62" Version="6.0.4" Language="en-US" Publisher="ZeroC" />
+        <Identity Id="0CEF9F9D-FA1F-45D0-9D1E-BBD2A86D5F62" Version="6.0.5" Language="en-US" Publisher="ZeroC" />
         <DisplayName>Ice Builder For Visual Studio 2022</DisplayName>
         <Description xml:space="preserve">Ice Builder manages the compilation of Slice (.ice) files to C++ and C#. It compiles your Slice files with slice2cpp and slice2cs, and allows you to specify the parameters provided to these compilers.</Description>
         <MoreInfo>https://github.com/zeroc-ice/ice-builder-visualstudio</MoreInfo>

--- a/IceBuilder.Shared/AssemblyInfo.cs
+++ b/IceBuilder.Shared/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisibleAttribute(false)]

--- a/IceBuilder.Shared/Builder.cs
+++ b/IceBuilder.Shared/Builder.cs
@@ -30,7 +30,7 @@ namespace IceBuilder
                 {
                     ThreadHelper.ThrowIfNotOnUIThread();
 
-                    // We need to set this before we acquire the build resources otherwise Msbuild will not see the changes.
+                    // We need to set this before we acquire the build resources otherwise MSBuild will not see the changes.
                     bool onlyLogCriticalEvents = msproject.ProjectCollection.OnlyLogCriticalEvents;
                     msproject.ProjectCollection.Loggers.Add(buildLogger);
                     msproject.ProjectCollection.OnlyLogCriticalEvents = false;

--- a/IceBuilder.Shared/Package.cs
+++ b/IceBuilder.Shared/Package.cs
@@ -19,7 +19,7 @@ using Task = System.Threading.Tasks.Task;
 namespace IceBuilder
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", "6.0.4", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", "6.0.5", IconResourceID = 400)]
     [ProvideOptionPage(typeof(IceOptionsPage), "Projects", "Ice Builder", 113, 0, true)]
     [ProvideAutoLoad(UIContextGuids80.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]
     [Guid(IceBuilderPackageString)]

--- a/IceBuilder.Shared/ProjectConverter.cs
+++ b/IceBuilder.Shared/ProjectConverter.cs
@@ -161,7 +161,7 @@ namespace IceBuilder
                                                         referenceItem.ItemType.Equals("Reference") &&
                                                         referenceItem.EvaluatedInclude.Split(
                                                             ",".ToCharArray()).ElementAt(0).Equals(r.Name));
-                                                if (item != null &&  item.HasMetadata("HintPath"))
+                                                if (item != null && item.GetMetadata("HintPath") != null)
                                                 {
                                                     var hintPath = item.GetMetadata("HintPath").UnevaluatedValue;
                                                     if (hintPath.Contains("$(IceAssembliesDir)"))

--- a/IceBuilder.Shared/ProjectUtil.cs
+++ b/IceBuilder.Shared/ProjectUtil.cs
@@ -301,7 +301,7 @@ namespace IceBuilder
                     return msproject.AllEvaluatedItems.Where(
                         item =>
                         {
-                            if (item.ItemType.Equals("Compile") && item.HasMetadata("SliceCompileSource"))
+                            if (item.ItemType.Equals("Compile") && item.GetMetadata("SliceCompileSource") != null)
                             {
                                 if (item.GetMetadataValue("SliceCompileSource").Equals(fileset.filename))
                                 {
@@ -343,14 +343,14 @@ namespace IceBuilder
                 return msproject.AllEvaluatedItems.Where(
                     item =>
                     {
-                        if (item.ItemType.Equals("ClCompile") && item.HasMetadata("SliceCompileSource"))
+                        if (item.ItemType.Equals("ClCompile") && item.GetMetadata("SliceCompileSource") != null)
                         {
                             if (item.GetMetadataValue("SliceCompileSource").Equals(fileset.filename))
                             {
                                 return !fileset.sources.ContainsKey(Path.GetFullPath(Path.Combine(projectDir, item.EvaluatedInclude)));
                             }
                         }
-                        else if (item.ItemType.Equals("ClInclude") && item.HasMetadata("SliceCompileSource"))
+                        else if (item.ItemType.Equals("ClInclude") && item.GetMetadata("SliceCompileSource") != null)
                         {
                             if (item.GetMetadataValue("SliceCompileSource").Equals(fileset.filename))
                             {
@@ -444,7 +444,7 @@ namespace IceBuilder
             ThreadHelper.ThrowIfNotOnUIThread();
             var projectDir = project.GetProjectBaseDirectory();
 
-            // Remove all Compile, ClCompile and ClInclude items that have an associted SliceCompileSource item
+            // Remove all Compile, ClCompile and ClInclude items that have an associated SliceCompileSource item
             // metadata that doesn't match any of the project SliceCompile items.
             if (project.IsCppProject())
             {
@@ -459,9 +459,10 @@ namespace IceBuilder
                         {
                             if (item.ItemType.Equals("ClCompile") || item.ItemType.Equals("ClInclude"))
                             {
-                                if (item.HasMetadata("SliceCompileSource"))
+                                var metadata = item.GetMetadata("SliceCompileSource");
+                                if (metadata != null)
                                 {
-                                    var value = item.GetMetadataValue("SliceCompileSource");
+                                    var value = metadata.EvaluatedValue;
                                     return !sliceCompile.Contains(value);
                                 }
                             }
@@ -477,19 +478,22 @@ namespace IceBuilder
                             item => item.ItemType.Equals("SliceCompile")).Select(
                             item => item.EvaluatedInclude);
 
-                        return msproject.AllEvaluatedItems.Where(
+                        var items = msproject.AllEvaluatedItems.Where(
                             item =>
                                 {
                                     if (item.ItemType.Equals("Compile"))
                                     {
-                                        if (item.HasMetadata("SliceCompileSource"))
+                                        var metadata = item.GetMetadata("SliceCompileSource");
+                                        if (metadata != null)
                                         {
-                                            var value = item.GetMetadataValue("SliceCompileSource");
+                                            var value = metadata.EvaluatedValue;
                                             return !sliceCompile.Contains(value);
                                         }
                                     }
                                     return false;
                                 }).Select(item => Path.Combine(projectDir, item.EvaluatedInclude)).ToList();
+
+                        return items;
                     }));
             }
 

--- a/IceBuilder/source.extension.vsixmanifest
+++ b/IceBuilder/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ef9502be-dbc2-4568-a846-02b8e42d04c2" Version="6.0.4" Language="en-US" Publisher="ZeroC" />
+        <Identity Id="ef9502be-dbc2-4568-a846-02b8e42d04c2" Version="6.0.5" Language="en-US" Publisher="ZeroC" />
         <DisplayName>Ice Builder</DisplayName>
         <Description xml:space="preserve">Ice Builder manages the compilation of Slice (.ice) files to C++ and C#. It compiles your Slice files with slice2cpp and slice2cs, and allows you to specify the parameters provided to these compilers.</Description>
         <MoreInfo>https://github.com/zeroc-ice/ice-builder-visualstudio</MoreInfo>

--- a/IceBuilderTemplates/CSharpSliceItemTemplate/Properties/AssemblyInfo.cs
+++ b/IceBuilderTemplates/CSharpSliceItemTemplate/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Reflection;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Visual Studio Extension")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: AssemblyDelaySign(false)]

--- a/IceBuilderTemplates/VCSliceItemTemplate/Properties/AssemblyInfo.cs
+++ b/IceBuilderTemplates/VCSliceItemTemplate/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Reflection;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Visual Studio Extension")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.3")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: AssemblyDelaySign(false)]

--- a/IceBuilder_Common.Next/Properties/AssemblyInfo.cs
+++ b/IceBuilder_Common.Next/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisible(false)]

--- a/IceBuilder_Common.Shared/IVsProjectExtension.cs
+++ b/IceBuilder_Common.Shared/IVsProjectExtension.cs
@@ -125,15 +125,16 @@ namespace IceBuilder
             var includeValue = FileUtil.RelativePath(projectDir, path);
             return project.WithProject((MSProject msproject) =>
                 {
-                    return msproject.AllEvaluatedItems.FirstOrDefault(
+                    var selectedItem = msproject.AllEvaluatedItems.FirstOrDefault(
                         item =>
                         {
                             return (item.ItemType.Equals("Compile") ||
                                     item.ItemType.Equals("ClCompile") ||
                                     item.ItemType.Equals("ClInclude")) &&
                                     item.EvaluatedInclude.Equals(includeValue) &&
-                                    item.HasMetadata("SliceCompileSource");
-                        }) != null;
+                                    item.GetMetadata("SliceCompileSource") != null;
+                        });
+                    return selectedItem != null;
                 });
         }
 

--- a/IceBuilder_Common.Shared/MSProjectExtension.cs
+++ b/IceBuilder_Common.Shared/MSProjectExtension.cs
@@ -26,7 +26,8 @@ namespace IceBuilder
             }
             else
             {
-                return item.HasMetadata(name) ? item.GetMetadata(name).UnevaluatedValue : defaultValue;
+                var metadata = item.GetMetadata(name);
+                return metadata != null ? metadata.UnevaluatedValue : defaultValue;
             }
         }
 

--- a/IceBuilder_Common/ProjectHelperI.cs
+++ b/IceBuilder_Common/ProjectHelperI.cs
@@ -199,7 +199,7 @@ namespace IceBuilder
                         // If there is a glob item that already match the evaluated include path we can remove the non
                         // glob item as it is a duplicate.
                         var globItem = msproject.AllEvaluatedItems.FirstOrDefault(i =>
-                            i.HasMetadata("SliceCompileSource") &&
+                            i.GetMetadata("SliceCompileSource") != null &&
                             !i.EvaluatedInclude.Equals(i.UnevaluatedInclude, StringComparison.OrdinalIgnoreCase) &&
                             i.EvaluatedInclude.Equals(item.Include, StringComparison.OrdinalIgnoreCase));
                         if (globItem != null)
@@ -231,7 +231,7 @@ namespace IceBuilder
                             // If there is a glob item that already match the evaluated include path we can remove the
                             // non glob item as it is a duplicate.
                             var globItem = msproject.AllEvaluatedItems.FirstOrDefault(i =>
-                                i.HasMetadata("SliceCompileSource") &&
+                                i.GetMetadata("SliceCompileSource") != null &&
                                 !i.EvaluatedInclude.Equals(i.UnevaluatedInclude, StringComparison.OrdinalIgnoreCase) &&
                                 i.EvaluatedInclude.Equals(item.Include, StringComparison.OrdinalIgnoreCase));
                             if (globItem != null)

--- a/IceBuilder_Common/Properties/AssemblyInfo.cs
+++ b/IceBuilder_Common/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisible(false)]

--- a/IceBuilder_VS2015/Properties/AssemblyInfo.cs
+++ b/IceBuilder_VS2015/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisible(false)]

--- a/IceBuilder_VS2017/Properties/AssemblyInfo.cs
+++ b/IceBuilder_VS2017/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisible(false)]

--- a/IceBuilder_VS2019/Properties/AssemblyInfo.cs
+++ b/IceBuilder_VS2019/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisible(false)]

--- a/IceBuilder_VS2022/Properties/AssemblyInfo.cs
+++ b/IceBuilder_VS2022/Properties/AssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("ZeroC, Inc.")]
 [assembly: AssemblyProduct("Ice Builder")]
 [assembly: AssemblyCopyright("Copyright (c) ZeroC, Inc.")]
-[assembly: AssemblyVersion("6.0.4")]
+[assembly: AssemblyVersion("6.0.5")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Microsoft.Build.Evaluation.ProjectItem HasMetadata is returning "true" even when a item has no such metadata. Reworked the code to use GetMetadata and check for null return value.